### PR TITLE
Update API group for DaemonSet to use apps group

### DIFF
--- a/deploy/kubevirt-hostpath-provisioner.yaml
+++ b/deploy/kubevirt-hostpath-provisioner.yaml
@@ -52,7 +52,7 @@ metadata:
   name: kubevirt-hostpath-provisioner-admin
   namespace: kubevirt-hostpath-provisioner
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: kubevirt-hostpath-provisioner


### PR DESCRIPTION
Signed-off-by: John Griffith john.griffith8@gmail.com
Signed-off-by: Alexander Wels <awels@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The extension group was removed in kubernetes 1.16
and replaced by the apps group. This patch just updates
the deployment manifest to use the new apps group and
should maintain backward compatibility for older versions.

Sure, the operator works, but I'm not using it so thought why not fix it here.

Fixes #36

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

